### PR TITLE
remove repeated debug logs when ostentus missing

### DIFF
--- a/libostentus.c
+++ b/libostentus.c
@@ -85,7 +85,6 @@ int ostentus_i2c_write(uint8_t reg, uint8_t data_len) {
 	}
 
 	if (_is_present == false) {
-		LOG_DBG("Ostentus not present, command not sent.");
 		return -EFAULT;
 	}
 


### PR DESCRIPTION
This commit removes the debug message sent each time a libostentus function is called but the Ostentus board is not present. These messages clutter the logs and are not a graceful way to fail. There is still an error message during initialization when Ostentus is not present. The user can also view the return code which will be `-EFAULT` when calling libostentus functions without an Ostentus connected.